### PR TITLE
if not moodle_enabled, postgress might mot be running, and wont work

### DIFF
--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -80,7 +80,7 @@
 
 - name: Execute moodle startup script
   script: moodle_installer
-  when: config.stat.exists is defined and not config.stat.exists
+  when: moodle_enabled and config.stat.exists is defined and not config.stat.exists
   
 
 - name: Restart postgresql-xs


### PR DESCRIPTION
discovered as an error, when just doing runansible