### PR TITLE
remove the attempt to comment out trusted domains in owncloud

### DIFF
--- a/roles/owncloud/tasks/owncloud_enabled.yml
+++ b/roles/owncloud/tasks/owncloud_enabled.yml
@@ -34,18 +34,3 @@
               state=absent
               dest="{{ owncloud_prefix }}/owncloud/config/config.php"
 
-# This is very version dependent
-
-- name: Remove Trusted Domains - comment before
-  lineinfile: dest="{{ owncloud_prefix }}/owncloud/config/config.php"
-              insertbefore='trusted_domains'
-              line='/*'
-              state=present
-  ignore_errors: true
-
-- name: Remove Trusted Domains - comment after
-  lineinfile: dest="{{ owncloud_prefix}}/owncloud/config/config.php"
-              insertafter='\),'
-              line='*/'
-              state=present
-  ignore_errors: true


### PR DESCRIPTION
Adam confirms that commenting out does not work on 9.1